### PR TITLE
docs(obs): add production observability evidence report (2026-02-18)

### DIFF
--- a/docs/observability-evidence-20260218.md
+++ b/docs/observability-evidence-20260218.md
@@ -1,0 +1,25 @@
+# Evidencia de observabilidad
+
+Fecha UTC: 2026-02-18T12:31:41.080Z
+Base URL: https://asistente-nespresso.onrender.com
+Estado health: ok
+Request ID (health): f02811db-ec48-4e10-9ec0-411c42180cf4
+
+## Resumen
+- Total requests: 14
+- 5xx count: 0
+- 5xx rate: 0.00% (límite 2.00%)
+- Rutas con breach p95>1000ms: 0
+- Rutas con breach p99>2000ms: 0
+
+## Alertas
+- Error rate 5xx: OK
+- Latencia p95: OK
+- Latencia p99: OK
+
+## Top rutas por tráfico (hasta 10)
+- GET /: req=6, err=6, p95=50ms, p99=50ms
+- GET /favicon.ico: req=3, err=3, p95=50ms, p99=50ms
+- HEAD /: req=2, err=2, p95=50ms, p99=50ms
+- GET /metrics: req=1, err=0, p95=50ms, p99=50ms
+- GET /health: req=1, err=0, p95=50ms, p99=50ms


### PR DESCRIPTION
## Summary\n- add production evidence report generated against https://asistente-nespresso.onrender.com\n- include health/metrics snapshot, 5xx rate and p95/p99 alert status\n\n## Evidence command\n- 
ode scripts/observability-evidence.mjs https://asistente-nespresso.onrender.com > docs/observability-evidence-20260218.md\n\n## Related\n- closes #31\n- epic #25

## Summary by Sourcery

Documentation:
- Add a dated observability evidence markdown report capturing health status, error rates, latency alerts, and top traffic routes for the production deployment.